### PR TITLE
Add the ability to run particular tasks after init

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,45 @@ lullabot-project config --json
 lullabot-project config --check-updates
 ```
 
+#### `task` - Run Specific Tasks
+
+Run specific tasks using stored configuration. This allows you to execute individual tasks on-demand.
+
+```bash
+lullabot-project task <tasks...> [options]
+```
+
+**Arguments:**
+- `<tasks...>` - Task names to run (can specify multiple)
+
+**Options:**
+- `-v, --verbose` - Verbose output
+- `--dry-run` - Show what would be done without executing
+
+**Examples:**
+```bash
+# Run a single task
+lullabot-project task rules
+
+# Run multiple tasks
+lullabot-project task rules memory-bank
+
+# Run with verbose output
+lullabot-project task rules -v
+
+# See what would be done without executing
+lullabot-project task rules --dry-run
+
+# Run tasks that were skipped during initial setup
+lullabot-project task memory-bank vscode-xdebug
+```
+
+**Use Cases:**
+- Add features that were initially skipped
+- Re-run failed tasks individually
+- Experiment with different task combinations
+- Update specific components without affecting others
+
 #### `remove` - Remove All Files and Configuration
 
 Remove all files and configuration created by lullabot-project.

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ import {
   initCommand,
   updateCommand,
   configCommand,
-  removeCommand
+  removeCommand,
+  taskCommand
 } from './src/commands.js';
 import { getToolVersion } from './src/file-operations.js';
 
@@ -62,6 +63,14 @@ program
   .option('--dry-run', 'Show what would be removed without executing')
   .option('-f, --force', 'Force removal without confirmation')
   .action(removeCommand);
+
+program
+  .command('task')
+  .description('Run specific tasks using stored configuration')
+  .argument('<tasks...>', 'Task names to run')
+  .option('-v, --verbose', 'Verbose output')
+  .option('--dry-run', 'Show what would be done without executing')
+  .action(taskCommand);
 
 // Handle errors gracefully
 program.exitOverride();

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,5 +1,11 @@
 import chalk from 'chalk';
-import { initSetup, updateSetup, showConfig, removeSetup } from './cli.js';
+import {
+  initSetup,
+  updateSetup,
+  showConfig,
+  removeSetup,
+  taskSetup
+} from './cli.js';
 
 /**
  * Initialize development environment setup command handler.
@@ -95,4 +101,31 @@ async function removeCommand(options) {
   }
 }
 
-export { initCommand, updateCommand, configCommand, removeCommand };
+/**
+ * Run specific tasks using stored configuration command handler.
+ * Wraps the taskSetup function with error handling and exit codes.
+ *
+ * @param {string[]} tasks - Array of task names to run
+ * @param {Object} options - Command line options and flags
+ * @param {boolean} options.dryRun - Whether to perform a dry run without making changes
+ * @param {boolean} options.verbose - Whether to show detailed output
+ */
+async function taskCommand(tasks, options) {
+  try {
+    await taskSetup(tasks, options);
+  } catch (error) {
+    console.error(chalk.red('❌ Task execution failed:'), error.message);
+    if (options.verbose) {
+      console.error(chalk.gray('Stack trace:'), error.stack);
+    }
+    process.exit(1);
+  }
+}
+
+export {
+  initCommand,
+  updateCommand,
+  configCommand,
+  removeCommand,
+  taskCommand
+};


### PR DESCRIPTION
Once a project has been initialized, it might be good to be able to run particular tasks afterwards. For example maybe you opted out for adding rules on cursor, but you changed your mind, being able to run `npx lullabot-project task rules` could then run the rules task without having to init again.